### PR TITLE
Completed "disabled counties" functionality

### DIFF
--- a/client/src/components/Combo.js
+++ b/client/src/components/Combo.js
@@ -6,6 +6,7 @@ export default function Combo(props) {
       name,
       value,
       setValue,
+      emptyValue=0,
       items,
       itemValuePath='id',
       itemLabelPath='name',
@@ -18,9 +19,18 @@ export default function Combo(props) {
   const combo = useRef(null);
 
   useEffect( () => {
+
     // Handle changes to the combo box
     function handleChange(e) {
-      setValue(e.target.value);
+      const value = e.target.value;
+
+    // Clear out the combo box if the user manually typed a disabled option      
+      const item = items.find( i => i[itemValuePath] === value );
+      if ( !item || item.disabled ) {
+        setValue(emptyValue);
+      } else {
+        setValue(value);
+      }
     }
 
     // Set up the combo box
@@ -30,13 +40,27 @@ export default function Combo(props) {
     combo.current.value = value;
     combo.current.disabled = disabled;
     combo.current.addEventListener('change', handleChange);
-    const el = combo.current; // Make a copy of the element for the cleanup function
 
+    // If the item is disabled, add an overlay to the item in the pop-up list
+    // that can't be clicked on, and grey out the text.
+    //
+    // If the item isn't disabled, just render the item name as normal.
+    combo.current.renderer = function(root, owner, model) {
+      if ( model.item.disabled ) {
+        root.innerHTML = `<div class="item" style="background: #fff; color: #aaa; margin: -.5rem -2rem; padding: .9rem 2rem; position: relative;">${model.item.name}</div>`;
+        root.querySelector('.item').addEventListener('click', (e) => {e.preventDefault(); e.stopPropagation(); return false;});
+      } else {
+        root.innerHTML = model.item.name;
+      };
+    };
+
+    const el = combo.current; // Make a copy of the element for the cleanup function
+    
     return function cleanup() {
       // Element might have been removed by this point, so use the copy      
       el.removeEventListener('change', handleChange);
     }
-  }, [value, setValue, items, itemValuePath, itemLabelPath, disabled]);
+  }, [value, setValue, emptyValue, items, itemValuePath, itemLabelPath, disabled]);
 
   return(
     <vaadin-combo-box

--- a/client/src/components/GetStartedForm.js
+++ b/client/src/components/GetStartedForm.js
@@ -9,21 +9,20 @@ export default function GetStartedForm() {
   const [charityId, setCharityId] = useState(0);
 
   // Append "Coming soon!" to the counties which aren't currently
-  // serviced by any charity
+  // serviced by any charity and mark them as "disabled" so they
+  // are greyed out and can't be selected.
   const counties = locations.counties.map( county => {
     let numCharitiesForCounty = charities.reduce( function(count, charity) {
       return count + ( charity.countyIds.includes(county.id) ? 1 : 0 );
     }, 0)
 
     if (numCharitiesForCounty > 0) {
-      return {
-        ...county,
-        available: true
-      };
+      return county;
     } else {
       return {
         ...county,
-        name: county.name + " (coming soon!)"
+        name: county.name + " (coming soon!)",
+        disabled: true
       };
     }
   });
@@ -32,7 +31,6 @@ export default function GetStartedForm() {
   useEffect( () => {
     setCharityId(0);
   }, [countyId]);
-
 
   return (
     <>
@@ -64,7 +62,7 @@ export default function GetStartedForm() {
               value={charityId}
               setValue={setCharityId}
               items={charities.filter(c => c.countyIds.includes(countyId))}
-              disabled={!countyId || !(counties.find(c => c.id === countyId).available)}
+              disabled={!countyId || (counties.find(c => c.id === countyId).disabled)}
               placeholder="select"
               style={{ backgroundColor: '#d2d9e1' }}
               className="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"


### PR DESCRIPTION
1. Modified `Combo` to handle disabled items
2. `GetStartedForm` now sets unavailable counties to `disabled`

**NB**: the dev version currently breaks in MS Edge due to spread operator usage (I think because Babel isn't transpiling for that browser). Production build works fine in Edge though.